### PR TITLE
FD-15409: Modified the rate-limiter middleware gemfile to incude XFF …

### DIFF
--- a/lib/rule.rb
+++ b/lib/rule.rb
@@ -8,7 +8,8 @@ class Rule
       :limit => 100,
       :per_ip => true,
       :per_url => false,
-      :token => false
+      :token => false,
+      :per_xff_ip => false
     }
     @options = default_options.merge(options)
 
@@ -56,6 +57,7 @@ class Rule
     path_url = @options[:include_host] ? request.host.to_s + request.path.to_s : request.path
     key = (@options[:per_url] ? path_url : @options[:match].to_s)
     key = key + request.ip.to_s if @options[:per_ip]
+    key = key + request.env['HTTP_X_FORWARDED_FOR'].to_s if @options[:per_xff_ip]
     key = key + request.params[@options[:token].to_s] if @options[:token]
     key
   end

--- a/rate-limiting.gemspec
+++ b/rate-limiting.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "rack-test"
   s.add_development_dependency "redis"
-  s.add_development_dependency "debugger"
+  s.add_development_dependency "byebug"
   s.add_dependency "json"
 
 end

--- a/spec/per_xff_ip_spec.rb
+++ b/spec/per_xff_ip_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+
+describe "per_xff_ip rule" do
+  include Rack::Test::Methods
+
+    it 'should not allow same url and same xff ips' do
+      get '/per_xff/url1', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.55"}
+      get '/per_xff/url1', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.55"}
+      last_response.body.should show_not_allowed_response
+    end
+    
+    it 'should allow same url but different xff ips' do
+      get '/per_xff/url2', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.60"}
+      get '/per_xff/url2', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.75"}
+      get '/per_xff/url2', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.80"}
+      last_response.body.should show_allowed_response
+    end
+
+    it 'should not allow different urls and same xff ips' do
+      get '/per_xff/url3', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.25"}
+      get '/per_xff/url4', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.25"}
+      last_response.body.should show_not_allowed_response
+    end
+
+    it 'should allow different urls and diff xff ips' do
+      get '/per_xff/url5', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.85"}
+      get '/per_xff/url6', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.95"}
+      last_response.body.should show_allowed_response
+    end
+
+    it 'should not allow same url if xff ips is not passed' do
+      get '/per_xff/url7', {}, {'HTTP_ACCEPT' => "text/html"}
+      get '/per_xff/url7', {}, {'HTTP_ACCEPT' => "text/html"}
+      last_response.body.should show_not_allowed_response
+    end
+
+    it 'should not allow different url if xff ips is not passed' do
+      get '/per_xff/url8', {}, {'HTTP_ACCEPT' => "text/html"}
+      get '/per_xff/url9', {}, {'HTTP_ACCEPT' => "text/html"}
+      last_response.body.should show_not_allowed_response
+    end
+
+    after(:all) do
+      $store.flushdb
+    end
+
+end
+
+describe "per_xff_ip_per_url rule" do
+  include Rack::Test::Methods
+
+    it 'should not allow same url and same xff ips' do
+      get '/per_xff_per_url/url1', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.55"}
+      get '/per_xff_per_url/url1', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.55"}
+      last_response.body.should show_not_allowed_response
+    end
+    
+    it 'should allow same url but different xff ips' do
+      get '/per_xff_per_url/url2', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.60"}
+      get '/per_xff_per_url/url2', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.75"}
+      get '/per_xff_per_url/url2', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.80"}
+      last_response.body.should show_allowed_response
+    end
+
+    it 'should allow different urls and same xff ips' do
+      get '/per_xff_per_url/url3', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.25"}
+      get '/per_xff_per_url/url4', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.25"}
+      last_response.body.should show_allowed_response
+    end
+
+    it 'should allow different urls and diff xff ips' do
+      get '/per_xff_per_url/url5', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.85"}
+      get '/per_xff_per_url/url6', {}, {'HTTP_ACCEPT' => "text/html", "HTTP_X_FORWARDED_FOR" => "10.23.44.95"}
+      last_response.body.should show_allowed_response
+    end
+
+    it 'should not allow same url if xff ips is not passed' do
+      get '/per_xff_per_url/url7', {}, {'HTTP_ACCEPT' => "text/html"}
+      get '/per_xff_per_url/url7', {}, {'HTTP_ACCEPT' => "text/html"}
+      last_response.body.should show_not_allowed_response
+    end
+
+    it 'should allow different url if xff ips is not passed' do
+      get '/per_xff_per_url/url8', {}, {'HTTP_ACCEPT' => "text/html"}
+      get '/per_xff_per_url/url9', {}, {'HTTP_ACCEPT' => "text/html"}
+      last_response.body.should show_allowed_response
+    end
+
+    after(:all) do
+      $store.flushdb
+    end
+
+end


### PR DESCRIPTION
FD-15409: The integration with Aloha for signup opens up a challenge of rate limiting a particular API using the client ip (X_Forwarded_For ip) and not just the request.ip (as request ip would be from Aloha). To implement this ability in rate-limiter middleware, have introduced a new config param "per_xff_ip" which if enabled during rule creation, the rate limiting will happen based on the X_FORWARDED_FOR ip parameter. However, the application that uses this config should have checks/authentications in place to verify is the request if coming from the trusted parties. 